### PR TITLE
Enable jumbo frames and UTs

### DIFF
--- a/bin/labmon_cni.py
+++ b/bin/labmon_cni.py
@@ -156,7 +156,12 @@ class CNIInterface:
         ifname = self.interface_data['interface']
         veth_id = containerid[:4]
         host_if_name = f"veth{veth_id}{self.index}"
-
+        # Check if the MTU annotation exists. If yes, assign the value. If not, assign the default 1500 bytes
+        if "mtu" in self.interface_data:
+            mtu = self.interface_data['mtu']
+        else:
+            mtu = 1500
+        
         OSexec.exec(f"modprobe --first-time 8021q")
         OSexec.exec(f"ip link set {MASTER_INTERFACE_NAME} up")
         OSexec.exec(f"ip link add link {MASTER_INTERFACE_NAME} name {MASTER_INTERFACE_NAME}.{vlan} type vlan id {vlan}")
@@ -170,6 +175,8 @@ class CNIInterface:
         OSexec.exec(f"ip netns add dummy1")
         OSexec.exec(f"ln -sfT {netns} /var/run/netns/{containerid}")
         OSexec.exec(f"ip link add {ifname} type veth peer name {host_if_name}", retry=100)
+        OSexec.exec(f"ip link set dev {host_if_name} mtu {mtu}")
+        OSexec.exec(f"ip link set dev {ifname} mtu {mtu}")
         OSexec.exec(f"ip link set {host_if_name} up")
         OSexec.exec(f"ip link set {host_if_name} master {phy_name}")
         OSexec.exec(f"ip link set {ifname} netns {containerid}")

--- a/bin/ut_cni.py
+++ b/bin/ut_cni.py
@@ -26,6 +26,10 @@ OLD_ANNOTATIONS = {
     "cisco.epfl/vlan_id": "517"
 }
 
+MTU_ANNOTATIONS = {
+    'cisco.epfl/interface_maps':
+        '[{"interface":"net1","vlan":519,"ip":"1.1.1.1","netmask":"","mtu":"9000"},{"interface":"net2","vlan":529,"ip":"2.2.2.2","netmask":"16","mtu":"1500"}]'
+}
 
 def log_exec(arg, retry=0):
     logging.info(f"-> (retry={retry} {arg} <-\n")
@@ -91,6 +95,34 @@ class lmUnitTest(unittest.TestCase):
         labmon_cni_K8s_Params_get_k8s_params.return_value = k8s_params
 
         labmon_cni_K8s_Params_get_annotations.return_value = OLD_ANNOTATIONS
+        K8 = labmon_cni.K8s_CNI()
+        K8.entrypoint()
+
+    @mock.patch('labmon_cni.K8s_Params.get_k8s_params')
+    @mock.patch('labmon_cni.K8s_Params.get_annotations')
+    @mock.patch('labmon_cni.OSexec.exec', log_exec)
+    @mock.patch('labmon_cni.OSexec.exec_get_output', log_exec_with_rc)
+    def test_up_new_style_with_mtu(self,
+                          labmon_cni_K8s_Params_get_annotations,
+                          labmon_cni_K8s_Params_get_k8s_params):
+        k8s_params = MOCKED_K8S_PARAMS
+        k8s_params['CNI_COMMAND'] = 'ADD'
+        labmon_cni_K8s_Params_get_k8s_params.return_value = k8s_params
+        labmon_cni_K8s_Params_get_annotations.return_value = MTU_ANNOTATIONS
+        K8 = labmon_cni.K8s_CNI()
+        K8.entrypoint()
+
+    @mock.patch('labmon_cni.K8s_Params.get_k8s_params')
+    @mock.patch('labmon_cni.K8s_Params.get_annotations')
+    @mock.patch('labmon_cni.OSexec.exec', log_exec)
+    @mock.patch('labmon_cni.OSexec.exec_get_output', log_exec_with_rc)
+    def test_down_new_style_with_mtu(self,
+                            labmon_cni_K8s_Params_get_annotations,
+                            labmon_cni_K8s_Params_get_k8s_params):
+        k8s_params = MOCKED_K8S_PARAMS
+        k8s_params['CNI_COMMAND'] = 'DEL'
+        labmon_cni_K8s_Params_get_k8s_params.return_value = k8s_params
+        labmon_cni_K8s_Params_get_annotations.return_value = MTU_ANNOTATIONS
         K8 = labmon_cni.K8s_CNI()
         K8.entrypoint()
 


### PR DESCRIPTION
Added UTs
Added support for configurable MTU

TEST RESULTS
```
cni_1  | 2021-02-03 13:19:06,581 [1] - DEBUG - k8s_data={'CNI_COMMAND': 'DEL', 'CNI_CONTAINERID': '1234cntid4321', 'CNI_NETNS': '33efdij', 'CNI_IFNAME': 'net1', 'CNI_ARGS': 'K8S_POD_NAMESPACE=123455;K8S_POD_NAME=MY_POD_NAME', 'CNI_PATH': '/bin'}
cni_1  | 2021-02-03 13:19:06,581 [1] - DEBUG - pod_data={'K8S_POD_NAME': 'MY_POD_NAME', 'K8S_POD_NAMESPACE': '123455'}
cni_1  | 2021-02-03 13:19:06,582 [1] - DEBUG - k8s_annotations={'cisco.epfl/interface_maps': '[{"interface":"net1","vlan":519,"ip":"1.1.1.1","netmask":""},{"interface":"net2","vlan":529,"ip":"2.2.2.2","netmask":"16"}]'}
cni_1  | 2021-02-03 13:19:06,582 [1] - INFO - Performing operation 2
cni_1  | 2021-02-03 13:19:06,583 [1] - INFO - STEP1: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': ''}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16'}]
cni_1  | 2021-02-03 13:19:06,583 [1] - INFO - No old style parameters present
cni_1  | 2021-02-03 13:19:06,583 [1] - INFO - STEP2: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': ''}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16'}]
cni_1  | 2021-02-03 13:19:06,584 [1] - INFO - STEP3: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': '255.255.255.0'}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16'}]
cni_1  | 2021-02-03 13:19:06,584 [1] - INFO - On interface teardown
cni_1  | 2021-02-03 13:19:06,584 [1] - INFO - -> (retry=0 ip link delete veth12340 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,584 [1] - INFO - On interface teardown
cni_1  | 2021-02-03 13:19:06,584 [1] - INFO - -> (retry=0 ip link delete veth12341 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,585 [1] - INFO - Processing done, returning={
cni_1  |     "cniVersion": "0.3.1",
cni_1  |     "interfaces": [
cni_1  |         {
cni_1  |             "name": "veth12340",
cni_1  |             "sandbox": "33efdij"
cni_1  |         },
cni_1  |         {
cni_1  |             "name": "veth12341",
cni_1  |             "sandbox": "33efdij"
cni_1  |         }
cni_1  |     ],
cni_1  |     "ips": [
cni_1  |         {
cni_1  |             "interface": 0,
cni_1  |             "version": "4"
cni_1  |         },
cni_1  |         {
cni_1  |             "interface": 1,
cni_1  |             "version": "4"
cni_1  |         }
cni_1  |     ]
cni_1  | }
cni_1  | .2021-02-03 13:19:06,586 [1] - DEBUG - k8s_data={'CNI_COMMAND': 'DEL', 'CNI_CONTAINERID': '1234cntid4321', 'CNI_NETNS': '33efdij', 'CNI_IFNAME': 'net1', 'CNI_ARGS': 'K8S_POD_NAMESPACE=123455;K8S_POD_NAME=MY_POD_NAME', 'CNI_PATH': '/bin'}
cni_1  | 2021-02-03 13:19:06,587 [1] - DEBUG - pod_data={'K8S_POD_NAME': 'MY_POD_NAME', 'K8S_POD_NAMESPACE': '123455'}
cni_1  | 2021-02-03 13:19:06,587 [1] - DEBUG - k8s_annotations={'cisco.epfl/interface_maps': '[{"interface":"net1","vlan":519,"ip":"1.1.1.1","netmask":"","mtu":"9000"},{"interface":"net2","vlan":529,"ip":"2.2.2.2","netmask":"16","mtu":"1500"}]'}
cni_1  | 2021-02-03 13:19:06,587 [1] - INFO - Performing operation 2
cni_1  | 2021-02-03 13:19:06,587 [1] - INFO - STEP1: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': '', 'mtu': '9000'}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16', 'mtu': '1500'}]
cni_1  | 2021-02-03 13:19:06,588 [1] - INFO - No old style parameters present
cni_1  | 2021-02-03 13:19:06,588 [1] - INFO - STEP2: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': '', 'mtu': '9000'}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16', 'mtu': '1500'}]
cni_1  | 2021-02-03 13:19:06,588 [1] - INFO - STEP3: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': '255.255.255.0', 'mtu': '9000'}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16', 'mtu': '1500'}]
cni_1  | 2021-02-03 13:19:06,589 [1] - INFO - On interface teardown
cni_1  | 2021-02-03 13:19:06,589 [1] - INFO - -> (retry=0 ip link delete veth12340 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,589 [1] - INFO - On interface teardown
cni_1  | 2021-02-03 13:19:06,589 [1] - INFO - -> (retry=0 ip link delete veth12341 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,590 [1] - INFO - Processing done, returning={
cni_1  |     "cniVersion": "0.3.1",
cni_1  |     "interfaces": [
cni_1  |         {
cni_1  |             "name": "veth12340",
cni_1  |             "sandbox": "33efdij"
cni_1  |         },
cni_1  |         {
cni_1  |             "name": "veth12341",
cni_1  |             "sandbox": "33efdij"
cni_1  |         }
cni_1  |     ],
cni_1  |     "ips": [
cni_1  |         {
cni_1  |             "interface": 0,
cni_1  |             "version": "4"
cni_1  |         },
cni_1  |         {
cni_1  |             "interface": 1,
cni_1  |             "version": "4"
cni_1  |         }
cni_1  |     ]
cni_1  | }
cni_1  | .2021-02-03 13:19:06,591 [1] - DEBUG - k8s_data={'CNI_COMMAND': 'DEL', 'CNI_CONTAINERID': '1234cntid4321', 'CNI_NETNS': '33efdij', 'CNI_IFNAME': 'net1', 'CNI_ARGS': 'K8S_POD_NAMESPACE=123455;K8S_POD_NAME=MY_POD_NAME', 'CNI_PATH': '/bin'}
cni_1  | 2021-02-03 13:19:06,591 [1] - DEBUG - pod_data={'K8S_POD_NAME': 'MY_POD_NAME', 'K8S_POD_NAMESPACE': '123455'}
cni_1  | 2021-02-03 13:19:06,591 [1] - DEBUG - k8s_annotations={'cisco.epfl/ip_address': '20.0.0.1', 'cisco.epfl/ip_prefix_length': '24', 'cisco.epfl/vlan_id': '517'}
cni_1  | 2021-02-03 13:19:06,591 [1] - INFO - Performing operation 2
cni_1  | 2021-02-03 13:19:06,592 [1] - INFO - STEP1: interface_maps is []
cni_1  | 2021-02-03 13:19:06,592 [1] - INFO - STEP2: interface_maps is [{'interface': 'net1', 'vlan': '517', 'netmask': '255.255.255.0', 'ip': '20.0.0.1'}]
cni_1  | 2021-02-03 13:19:06,593 [1] - INFO - STEP3: interface_maps is [{'interface': 'net1', 'vlan': '517', 'netmask': '255.255.255.0', 'ip': '20.0.0.1'}]
cni_1  | 2021-02-03 13:19:06,593 [1] - INFO - On interface teardown
cni_1  | 2021-02-03 13:19:06,593 [1] - INFO - -> (retry=0 ip link delete veth12340 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,594 [1] - INFO - Processing done, returning={
cni_1  |     "cniVersion": "0.3.1",
cni_1  |     "interfaces": [
cni_1  |         {
cni_1  |             "name": "veth12340",
cni_1  |             "sandbox": "33efdij"
cni_1  |         }
cni_1  |     ],
cni_1  |     "ips": [
cni_1  |         {
cni_1  |             "interface": 0,
cni_1  |             "version": "4"
cni_1  |         }
cni_1  |     ]
cni_1  | }
cni_1  | .2021-02-03 13:19:06,595 [1] - DEBUG - k8s_data={'CNI_COMMAND': 'ADD', 'CNI_CONTAINERID': '1234cntid4321', 'CNI_NETNS': '33efdij', 'CNI_IFNAME': 'net1', 'CNI_ARGS': 'K8S_POD_NAMESPACE=123455;K8S_POD_NAME=MY_POD_NAME', 'CNI_PATH': '/bin'}
cni_1  | 2021-02-03 13:19:06,595 [1] - DEBUG - pod_data={'K8S_POD_NAME': 'MY_POD_NAME', 'K8S_POD_NAMESPACE': '123455'}
cni_1  | 2021-02-03 13:19:06,595 [1] - DEBUG - k8s_annotations={'cisco.epfl/interface_maps': '[{"interface":"net1","vlan":519,"ip":"1.1.1.1","netmask":""},{"interface":"net2","vlan":529,"ip":"2.2.2.2","netmask":"16"}]'}
cni_1  | 2021-02-03 13:19:06,595 [1] - INFO - Performing operation 1
cni_1  | 2021-02-03 13:19:06,596 [1] - INFO - STEP1: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': ''}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16'}]
cni_1  | 2021-02-03 13:19:06,596 [1] - INFO - No old style parameters present
cni_1  | 2021-02-03 13:19:06,596 [1] - INFO - STEP2: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': ''}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16'}]
cni_1  | 2021-02-03 13:19:06,596 [1] - INFO - STEP3: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': '255.255.255.0'}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16'}]
cni_1  | 2021-02-03 13:19:06,596 [1] - INFO - On interface bringup
cni_1  | 2021-02-03 13:19:06,597 [1] - INFO - -> (retry=0 modprobe --first-time 8021q <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,597 [1] - INFO - -> (retry=0 ip link set ens192 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,597 [1] - INFO - -> (retry=0 ip link add link ens192 name ens192.519 type vlan id 519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,598 [1] - INFO - -> (retry=0 ip link set ens192.519 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,598 [1] - INFO - -> (retry=0 brctl addbr phy_519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,598 [1] - INFO - -> (retry=0 brctl addif phy_519 ens192.519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,598 [1] - INFO - -> (retry=0 ip link set phy_519 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,599 [1] - INFO - -> (retry=0 iptables -C FORWARD -i phy_519  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,599 [1] - INFO - -> (retry=0 iptables -A FORWARD -i phy_519  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,599 [1] - INFO - -> (retry=0 ip netns add dummy1 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,600 [1] - INFO - -> (retry=0 ln -sfT 33efdij /var/run/netns/1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,600 [1] - INFO - -> (retry=100 ip link add net1 type veth peer name veth12340 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,600 [1] - INFO - -> (retry=0 ip link set dev veth12340 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,601 [1] - INFO - -> (retry=0 ip link set dev net1 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,601 [1] - INFO - -> (retry=0 ip link set veth12340 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,601 [1] - INFO - -> (retry=0 ip link set veth12340 master phy_519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,602 [1] - INFO - -> (retry=0 ip link set net1 netns 1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,602 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip link set net1 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,602 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip addr add 1.1.1.1/24 dev net1 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,603 [1] - INFO - -> ip netns exec 1234cntid4321 ip link show net1 | awk '/ether/ {print $2}' <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,603 [1] - INFO - On interface bringup
cni_1  | 2021-02-03 13:19:06,603 [1] - INFO - -> (retry=0 modprobe --first-time 8021q <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,603 [1] - INFO - -> (retry=0 ip link set ens192 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,603 [1] - INFO - -> (retry=0 ip link add link ens192 name ens192.529 type vlan id 529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,604 [1] - INFO - -> (retry=0 ip link set ens192.529 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,604 [1] - INFO - -> (retry=0 brctl addbr phy_529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,604 [1] - INFO - -> (retry=0 brctl addif phy_529 ens192.529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,604 [1] - INFO - -> (retry=0 ip link set phy_529 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,604 [1] - INFO - -> (retry=0 iptables -C FORWARD -i phy_529  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,605 [1] - INFO - -> (retry=0 iptables -A FORWARD -i phy_529  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,605 [1] - INFO - -> (retry=0 ip netns add dummy1 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,605 [1] - INFO - -> (retry=0 ln -sfT 33efdij /var/run/netns/1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,606 [1] - INFO - -> (retry=100 ip link add net2 type veth peer name veth12341 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,606 [1] - INFO - -> (retry=0 ip link set dev veth12341 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,607 [1] - INFO - -> (retry=0 ip link set dev net2 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,607 [1] - INFO - -> (retry=0 ip link set veth12341 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,608 [1] - INFO - -> (retry=0 ip link set veth12341 master phy_529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,608 [1] - INFO - -> (retry=0 ip link set net2 netns 1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,608 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip link set net2 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,609 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip addr add 2.2.2.2/16 dev net2 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,609 [1] - INFO - -> ip netns exec 1234cntid4321 ip link show net2 | awk '/ether/ {print $2}' <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,610 [1] - INFO - Processing done, returning={
cni_1  |     "cniVersion": "0.3.1",
cni_1  |     "interfaces": [
cni_1  |         {
cni_1  |             "mac": "de:ad:be:ee:ef",
cni_1  |             "name": "veth12340",
cni_1  |             "sandbox": "33efdij"
cni_1  |         },
cni_1  |         {
cni_1  |             "mac": "de:ad:be:ee:ef",
cni_1  |             "name": "veth12341",
cni_1  |             "sandbox": "33efdij"
cni_1  |         }
cni_1  |     ],
cni_1  |     "ips": [
cni_1  |         {
cni_1  |             "address": "1.1.1.1/24",
cni_1  |             "interface": 0,
cni_1  |             "version": "4"
cni_1  |         },
cni_1  |         {
cni_1  |             "address": "2.2.2.2/16",
cni_1  |             "interface": 1,
cni_1  |             "version": "4"
cni_1  |         }
cni_1  |     ]
cni_1  | }
cni_1  | .2021-02-03 13:19:06,611 [1] - DEBUG - k8s_data={'CNI_COMMAND': 'ADD', 'CNI_CONTAINERID': '1234cntid4321', 'CNI_NETNS': '33efdij', 'CNI_IFNAME': 'net1', 'CNI_ARGS': 'K8S_POD_NAMESPACE=123455;K8S_POD_NAME=MY_POD_NAME', 'CNI_PATH': '/bin'}
cni_1  | 2021-02-03 13:19:06,612 [1] - DEBUG - pod_data={'K8S_POD_NAME': 'MY_POD_NAME', 'K8S_POD_NAMESPACE': '123455'}
cni_1  | 2021-02-03 13:19:06,612 [1] - DEBUG - k8s_annotations={'cisco.epfl/interface_maps': '[{"interface":"net1","vlan":519,"ip":"1.1.1.1","netmask":"","mtu":"9000"},{"interface":"net2","vlan":529,"ip":"2.2.2.2","netmask":"16","mtu":"1500"}]'}
cni_1  | 2021-02-03 13:19:06,612 [1] - INFO - Performing operation 1
cni_1  | 2021-02-03 13:19:06,613 [1] - INFO - STEP1: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': '', 'mtu': '9000'}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16', 'mtu': '1500'}]
cni_1  | 2021-02-03 13:19:06,613 [1] - INFO - No old style parameters present
cni_1  | 2021-02-03 13:19:06,614 [1] - INFO - STEP2: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': '', 'mtu': '9000'}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16', 'mtu': '1500'}]
cni_1  | 2021-02-03 13:19:06,615 [1] - INFO - STEP3: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': '1.1.1.1', 'netmask': '255.255.255.0', 'mtu': '9000'}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16', 'mtu': '1500'}]
cni_1  | 2021-02-03 13:19:06,615 [1] - INFO - On interface bringup
cni_1  | 2021-02-03 13:19:06,616 [1] - INFO - -> (retry=0 modprobe --first-time 8021q <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,616 [1] - INFO - -> (retry=0 ip link set ens192 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,617 [1] - INFO - -> (retry=0 ip link add link ens192 name ens192.519 type vlan id 519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,617 [1] - INFO - -> (retry=0 ip link set ens192.519 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,617 [1] - INFO - -> (retry=0 brctl addbr phy_519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,617 [1] - INFO - -> (retry=0 brctl addif phy_519 ens192.519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,618 [1] - INFO - -> (retry=0 ip link set phy_519 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,618 [1] - INFO - -> (retry=0 iptables -C FORWARD -i phy_519  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,618 [1] - INFO - -> (retry=0 iptables -A FORWARD -i phy_519  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,618 [1] - INFO - -> (retry=0 ip netns add dummy1 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,619 [1] - INFO - -> (retry=0 ln -sfT 33efdij /var/run/netns/1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,619 [1] - INFO - -> (retry=100 ip link add net1 type veth peer name veth12340 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,619 [1] - INFO - -> (retry=0 ip link set dev veth12340 mtu 9000 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,620 [1] - INFO - -> (retry=0 ip link set dev net1 mtu 9000 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,620 [1] - INFO - -> (retry=0 ip link set veth12340 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,620 [1] - INFO - -> (retry=0 ip link set veth12340 master phy_519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,620 [1] - INFO - -> (retry=0 ip link set net1 netns 1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,621 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip link set net1 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,621 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip addr add 1.1.1.1/24 dev net1 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,621 [1] - INFO - -> ip netns exec 1234cntid4321 ip link show net1 | awk '/ether/ {print $2}' <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,622 [1] - INFO - On interface bringup
cni_1  | 2021-02-03 13:19:06,622 [1] - INFO - -> (retry=0 modprobe --first-time 8021q <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,622 [1] - INFO - -> (retry=0 ip link set ens192 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,623 [1] - INFO - -> (retry=0 ip link add link ens192 name ens192.529 type vlan id 529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,623 [1] - INFO - -> (retry=0 ip link set ens192.529 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,623 [1] - INFO - -> (retry=0 brctl addbr phy_529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,624 [1] - INFO - -> (retry=0 brctl addif phy_529 ens192.529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,624 [1] - INFO - -> (retry=0 ip link set phy_529 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,624 [1] - INFO - -> (retry=0 iptables -C FORWARD -i phy_529  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,625 [1] - INFO - -> (retry=0 iptables -A FORWARD -i phy_529  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,625 [1] - INFO - -> (retry=0 ip netns add dummy1 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,625 [1] - INFO - -> (retry=0 ln -sfT 33efdij /var/run/netns/1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,626 [1] - INFO - -> (retry=100 ip link add net2 type veth peer name veth12341 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,626 [1] - INFO - -> (retry=0 ip link set dev veth12341 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,626 [1] - INFO - -> (retry=0 ip link set dev net2 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,626 [1] - INFO - -> (retry=0 ip link set veth12341 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,627 [1] - INFO - -> (retry=0 ip link set veth12341 master phy_529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,627 [1] - INFO - -> (retry=0 ip link set net2 netns 1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,627 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip link set net2 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,628 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip addr add 2.2.2.2/16 dev net2 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,628 [1] - INFO - -> ip netns exec 1234cntid4321 ip link show net2 | awk '/ether/ {print $2}' <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,629 [1] - INFO - Processing done, returning={
cni_1  |     "cniVersion": "0.3.1",
cni_1  |     "interfaces": [
cni_1  |         {
cni_1  |             "mac": "de:ad:be:ee:ef",
cni_1  |             "name": "veth12340",
cni_1  |             "sandbox": "33efdij"
cni_1  |         },
cni_1  |         {
cni_1  |             "mac": "de:ad:be:ee:ef",
cni_1  |             "name": "veth12341",
cni_1  |             "sandbox": "33efdij"
cni_1  |         }
cni_1  |     ],
cni_1  |     "ips": [
cni_1  |         {
cni_1  |             "address": "1.1.1.1/24",
cni_1  |             "interface": 0,
cni_1  |             "version": "4"
cni_1  |         },
cni_1  |         {
cni_1  |             "address": "2.2.2.2/16",
cni_1  |             "interface": 1,
cni_1  |             "version": "4"
cni_1  |         }
cni_1  |     ]
cni_1  | }
cni_1  | .2021-02-03 13:19:06,631 [1] - DEBUG - k8s_data={'CNI_COMMAND': 'ADD', 'CNI_CONTAINERID': '1234cntid4321', 'CNI_NETNS': '33efdij', 'CNI_IFNAME': 'net1', 'CNI_ARGS': 'K8S_POD_NAMESPACE=123455;K8S_POD_NAME=MY_POD_NAME', 'CNI_PATH': '/bin'}
cni_1  | 2021-02-03 13:19:06,631 [1] - DEBUG - pod_data={'K8S_POD_NAME': 'MY_POD_NAME', 'K8S_POD_NAMESPACE': '123455'}
cni_1  | 2021-02-03 13:19:06,631 [1] - DEBUG - k8s_annotations={'cisco.epfl/interface_maps': '[{"interface":"net1","vlan":519,"ip": null,"netmask": null},{"interface":"net2","vlan":529,"ip":"2.2.2.2","netmask":"16"}]'}
cni_1  | 2021-02-03 13:19:06,632 [1] - INFO - Performing operation 1
cni_1  | 2021-02-03 13:19:06,632 [1] - INFO - STEP1: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': None, 'netmask': None}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16'}]
cni_1  | 2021-02-03 13:19:06,632 [1] - INFO - No old style parameters present
cni_1  | 2021-02-03 13:19:06,632 [1] - INFO - STEP2: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': None, 'netmask': None}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16'}]
cni_1  | 2021-02-03 13:19:06,633 [1] - INFO - STEP3: interface_maps is [{'interface': 'net1', 'vlan': 519, 'ip': None, 'netmask': None}, {'interface': 'net2', 'vlan': 529, 'ip': '2.2.2.2', 'netmask': '16'}]
cni_1  | 2021-02-03 13:19:06,633 [1] - INFO - On interface bringup
cni_1  | 2021-02-03 13:19:06,633 [1] - INFO - -> (retry=0 modprobe --first-time 8021q <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,634 [1] - INFO - -> (retry=0 ip link set ens192 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,634 [1] - INFO - -> (retry=0 ip link add link ens192 name ens192.519 type vlan id 519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,634 [1] - INFO - -> (retry=0 ip link set ens192.519 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,634 [1] - INFO - -> (retry=0 brctl addbr phy_519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,634 [1] - INFO - -> (retry=0 brctl addif phy_519 ens192.519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,635 [1] - INFO - -> (retry=0 ip link set phy_519 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,635 [1] - INFO - -> (retry=0 iptables -C FORWARD -i phy_519  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,635 [1] - INFO - -> (retry=0 iptables -A FORWARD -i phy_519  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,635 [1] - INFO - -> (retry=0 ip netns add dummy1 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,635 [1] - INFO - -> (retry=0 ln -sfT 33efdij /var/run/netns/1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,636 [1] - INFO - -> (retry=100 ip link add net1 type veth peer name veth12340 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,636 [1] - INFO - -> (retry=0 ip link set dev veth12340 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,636 [1] - INFO - -> (retry=0 ip link set dev net1 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,636 [1] - INFO - -> (retry=0 ip link set veth12340 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,636 [1] - INFO - -> (retry=0 ip link set veth12340 master phy_519 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,637 [1] - INFO - -> (retry=0 ip link set net1 netns 1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,637 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip link set net1 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,638 [1] - INFO - Error setting IP address
cni_1  | 2021-02-03 13:19:06,638 [1] - INFO - -> ip netns exec 1234cntid4321 ip link show net1 | awk '/ether/ {print $2}' <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,638 [1] - INFO - On interface bringup
cni_1  | 2021-02-03 13:19:06,639 [1] - INFO - -> (retry=0 modprobe --first-time 8021q <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,640 [1] - INFO - -> (retry=0 ip link set ens192 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,640 [1] - INFO - -> (retry=0 ip link add link ens192 name ens192.529 type vlan id 529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,640 [1] - INFO - -> (retry=0 ip link set ens192.529 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,640 [1] - INFO - -> (retry=0 brctl addbr phy_529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,641 [1] - INFO - -> (retry=0 brctl addif phy_529 ens192.529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,641 [1] - INFO - -> (retry=0 ip link set phy_529 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,642 [1] - INFO - -> (retry=0 iptables -C FORWARD -i phy_529  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,642 [1] - INFO - -> (retry=0 iptables -A FORWARD -i phy_529  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,643 [1] - INFO - -> (retry=0 ip netns add dummy1 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,643 [1] - INFO - -> (retry=0 ln -sfT 33efdij /var/run/netns/1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,644 [1] - INFO - -> (retry=100 ip link add net2 type veth peer name veth12341 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,644 [1] - INFO - -> (retry=0 ip link set dev veth12341 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,645 [1] - INFO - -> (retry=0 ip link set dev net2 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,645 [1] - INFO - -> (retry=0 ip link set veth12341 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,645 [1] - INFO - -> (retry=0 ip link set veth12341 master phy_529 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,645 [1] - INFO - -> (retry=0 ip link set net2 netns 1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,645 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip link set net2 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,645 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip addr add 2.2.2.2/16 dev net2 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,646 [1] - INFO - -> ip netns exec 1234cntid4321 ip link show net2 | awk '/ether/ {print $2}' <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,647 [1] - INFO - Processing done, returning={
cni_1  |     "cniVersion": "0.3.1",
cni_1  |     "interfaces": [
cni_1  |         {
cni_1  |             "mac": "de:ad:be:ee:ef",
cni_1  |             "name": "veth12340",
cni_1  |             "sandbox": "33efdij"
cni_1  |         },
cni_1  |         {
cni_1  |             "mac": "de:ad:be:ee:ef",
cni_1  |             "name": "veth12341",
cni_1  |             "sandbox": "33efdij"
cni_1  |         }
cni_1  |     ],
cni_1  |     "ips": [
cni_1  |         {
cni_1  |             "interface": 0,
cni_1  |             "version": "4"
cni_1  |         },
cni_1  |         {
cni_1  |             "address": "2.2.2.2/16",
cni_1  |             "interface": 1,
cni_1  |             "version": "4"
cni_1  |         }
cni_1  |     ]
cni_1  | }
cni_1  | .2021-02-03 13:19:06,649 [1] - DEBUG - k8s_data={'CNI_COMMAND': 'ADD', 'CNI_CONTAINERID': '1234cntid4321', 'CNI_NETNS': '33efdij', 'CNI_IFNAME': 'net1', 'CNI_ARGS': 'K8S_POD_NAMESPACE=123455;K8S_POD_NAME=MY_POD_NAME', 'CNI_PATH': '/bin'}
cni_1  | 2021-02-03 13:19:06,649 [1] - DEBUG - pod_data={'K8S_POD_NAME': 'MY_POD_NAME', 'K8S_POD_NAMESPACE': '123455'}
cni_1  | 2021-02-03 13:19:06,650 [1] - DEBUG - k8s_annotations={'cisco.epfl/ip_address': '20.0.0.1', 'cisco.epfl/ip_prefix_length': '24', 'cisco.epfl/vlan_id': '517'}
cni_1  | 2021-02-03 13:19:06,650 [1] - INFO - Performing operation 1
cni_1  | 2021-02-03 13:19:06,650 [1] - INFO - STEP1: interface_maps is []
cni_1  | 2021-02-03 13:19:06,650 [1] - INFO - STEP2: interface_maps is [{'interface': 'net1', 'vlan': '517', 'netmask': '255.255.255.0', 'ip': '20.0.0.1'}]
cni_1  | 2021-02-03 13:19:06,650 [1] - INFO - STEP3: interface_maps is [{'interface': 'net1', 'vlan': '517', 'netmask': '255.255.255.0', 'ip': '20.0.0.1'}]
cni_1  | 2021-02-03 13:19:06,650 [1] - INFO - On interface bringup
cni_1  | 2021-02-03 13:19:06,651 [1] - INFO - -> (retry=0 modprobe --first-time 8021q <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,651 [1] - INFO - -> (retry=0 ip link set ens192 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,651 [1] - INFO - -> (retry=0 ip link add link ens192 name ens192.517 type vlan id 517 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,651 [1] - INFO - -> (retry=0 ip link set ens192.517 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,652 [1] - INFO - -> (retry=0 brctl addbr phy_517 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,653 [1] - INFO - -> (retry=0 brctl addif phy_517 ens192.517 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,653 [1] - INFO - -> (retry=0 ip link set phy_517 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,653 [1] - INFO - -> (retry=0 iptables -C FORWARD -i phy_517  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,653 [1] - INFO - -> (retry=0 iptables -A FORWARD -i phy_517  -j ACCEPT <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,653 [1] - INFO - -> (retry=0 ip netns add dummy1 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,653 [1] - INFO - -> (retry=0 ln -sfT 33efdij /var/run/netns/1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,653 [1] - INFO - -> (retry=100 ip link add net1 type veth peer name veth12340 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,653 [1] - INFO - -> (retry=0 ip link set dev veth12340 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,654 [1] - INFO - -> (retry=0 ip link set dev net1 mtu 1500 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,654 [1] - INFO - -> (retry=0 ip link set veth12340 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,656 [1] - INFO - -> (retry=0 ip link set veth12340 master phy_517 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,656 [1] - INFO - -> (retry=0 ip link set net1 netns 1234cntid4321 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,657 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip link set net1 up <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,658 [1] - INFO - -> (retry=0 ip netns exec 1234cntid4321 ip addr add 20.0.0.1/24 dev net1 <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,658 [1] - INFO - -> ip netns exec 1234cntid4321 ip link show net1 | awk '/ether/ {print $2}' <-
cni_1  |
cni_1  | 2021-02-03 13:19:06,658 [1] - INFO - Processing done, returning={
cni_1  |     "cniVersion": "0.3.1",
cni_1  |     "interfaces": [
cni_1  |         {
cni_1  |             "mac": "de:ad:be:ee:ef",
cni_1  |             "name": "veth12340",
cni_1  |             "sandbox": "33efdij"
cni_1  |         }
cni_1  |     ],
cni_1  |     "ips": [
cni_1  |         {
cni_1  |             "address": "20.0.0.1/24",
cni_1  |             "interface": 0,
cni_1  |             "version": "4"
cni_1  |         }
cni_1  |     ]
cni_1  | }
cni_1  | .
cni_1  | ----------------------------------------------------------------------
cni_1  | Ran 7 tests in 0.079s
cni_1  |
cni_1  | OK
```